### PR TITLE
Ensure navigation menu appears on all report pages

### DIFF
--- a/posts/posts_1-100.md
+++ b/posts/posts_1-100.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 1–100"
+---
+
 **643 report_number:5 report_date:1975-02-16**
 **Headline:** \"The Cosmic Warning: Earth's Past and Future in the Stars 🌍✨\"  
 

--- a/posts/posts_101-200.md
+++ b/posts/posts_101-200.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 101–200"
+---
+
 **2197 report_number:101 report_date:1978-01-16**
 **Headline:** \"Billy Meier's Plejaren Contacts: A Fight for Truth Against Power\"  
 

--- a/posts/posts_201-300.md
+++ b/posts/posts_201-300.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 201–300"
+---
+
 **835 report_number:201 report_date:1985-06-05**
 **Headline:** \"The Future of Earth: A Cosmic Perspective from the Plejaren\"  
 

--- a/posts/posts_301-400.md
+++ b/posts/posts_301-400.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 301–400"
+---
+
 **1616 report_number:301 report_date:2001-04-24**
  \"Guardians of Earth: Plejaren Warnings on Environmental Responsibility\"**  
 The Plejaren contact reports emphasize critical warnings about humanity's environmental impact and the urgent need for change. They highlight that our planet is suffering due to neglect and exploitation, urging us to adopt sustainable practices and respect for nature. The teachings convey that every individual has a role in protecting the Earth, as our well-being is intrinsically linked to the health of our environment. The Plejaren call for a collective awakening to environmental issues, advocating for action that aligns with ecological balance and harmony. By embracing responsible choices, we can create a sustainable future for generations to come. It's time to listen to these extraterrestrial guardians and become stewards of our planet!  

--- a/posts/posts_401-500.md
+++ b/posts/posts_401-500.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 401–500"
+---
+
 **437 report_number:401 report_date:2005-10-15**
 ### Post 2: \"A Wake-Up Call: Environmental Responsibility\"
 The Billy Meier contact reports serve as a stark reminder of humanity's impact on the environment. The Plejaren warn that our destructive activities have reached a tipping point, leading to increasingly severe weather patterns and ecological imbalances. They stress the urgent need for sustainable practices and collective action to restore balance to our planet. The reports highlight that environmental awareness isn't just about conservation; it's about recognizing our role as stewards of Earth. By adopting eco-friendly habits and advocating for policy changes, we can mitigate the damage and create a healthier world for future generations. Let's heed this call and take actionable steps toward a sustainable future! #EnvironmentalAwareness #Sustainability #FutureOfHumanity

--- a/posts/posts_501-600.md
+++ b/posts/posts_501-600.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 501–600"
+---
+
 **1015 report_number:501 report_date:2010-09-01**
 ### Post 1: \"Unlocking Spiritual Growth: Insights from Beyond!\"
 In the Billy Meier contact reports, the Plejaren emphasize the importance of spiritual development as a vital aspect of human existence. They stress that genuine growth requires self-awareness, a commitment to understanding one's thoughts and emotions, and a willingness to embrace personal responsibility. The Plejaren's teachings encourage us to look beyond materialism, fostering a deeper connection to our inner selves and the universe. This journey of enlightenment not only elevates the individual but also contributes positively to society. By cultivating compassion, wisdom, and harmony, we can transform our surroundings and inspire others to do the same. The message is clear: spiritual growth is not just a personal journey; it is a collective responsibility that shapes our future. #Spirituality #PersonalGrowth #CollectiveResponsibility #FutureOfHumanity

--- a/posts/posts_601-700.md
+++ b/posts/posts_601-700.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 601–700"
+---
+
 **472 report_number:601 report_date:2014-11-10**
 ### Post 1: \"Unlocking Spiritual Growth: Wisdom from the Plejaren\"
 The Billy Meier contact reports provide a fascinating insight into the teachings of the Plejaren, extraterrestrial beings who emphasize the importance of spiritual growth. These teachings encourage individuals to look within, nurture self-awareness, and seek a higher understanding of existence. Spirituality, as described by the Plejaren, is not just about personal enlightenment but also about fostering harmony and balance in our interactions with others and the planet. The message is clear: as we evolve spiritually, we contribute to a more peaceful and enlightened world. The reports remind us that spiritual growth is a shared journey, one that transcends borders and unites humanity in its quest for truth and wisdom. Embrace your spiritual path and explore the depths of your existence! 

--- a/posts/posts_701-800.md
+++ b/posts/posts_701-800.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 701–800"
+---
+
 **887 report_number:701 report_date:2018-02-01**
 ### Post 2: **Protect Our Planet: Plejaren Warnings on Environmental Awareness**
 The Plejaren have long warned humanity about the dire consequences of environmental neglect. According to the Billy Meier contact reports, our planet is at a critical juncture, facing unprecedented challenges due to pollution, climate change, and overconsumption. These messages highlight the urgency of adopting sustainable practices and protecting our natural resources. The Plejaren encourage a return to balance, stressing the need for humanity to live in harmony with nature. By raising awareness and taking action, we can prevent irreversible damage to our planet. Their insights resonate today as we confront the reality of environmental degradation. It's time to listen and act! #EnvironmentalAwareness #Sustainability #FutureOfHumanity

--- a/posts/posts_801-900.md
+++ b/posts/posts_801-900.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "Reports 801–900"
+---
+
 **137 report_number:801 report_date:2022-05-01**
 ### Post 2: \"Protect Our Planet: Lessons from Extraterrestrial Wisdom\"
 Billy Meier's contact reports with the Plejaren bring urgent messages about environmental awareness and our responsibility towards Earth. The Plejaren stress that humanity's actions have dire consequences for the planet, warning that neglecting ecological balance can lead to irreversible damage. They advocate for sustainable living, emphasizing the need to respect nature and utilize technology responsibly. The reports serve as a clarion call for individuals to take action, from reducing waste to supporting renewable energy initiatives. By fostering a culture of environmental stewardship, we can ensure a healthier planet for future generations. Join the movement to protect our Earth! #EnvironmentalAwareness #Sustainability #ProtectOurPlanet #FutureOfHumanity

--- a/social.html
+++ b/social.html
@@ -5,13 +5,13 @@ title: "Social Media Posts"
 
 <h1 class="mb-4 text-center">Social Media Posts</h1>
 <ul class="list-group">
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_1-100.md">Reports 1–100</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_101-200.md">Reports 101–200</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_201-300.md">Reports 201–300</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_301-400.md">Reports 301–400</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_401-500.md">Reports 401–500</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_501-600.md">Reports 501–600</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_601-700.md">Reports 601–700</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_701-800.md">Reports 701–800</a></li>
-  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_801-900.md">Reports 801–900</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_1-100.html">Reports 1–100</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_101-200.html">Reports 101–200</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_201-300.html">Reports 201–300</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_301-400.html">Reports 301–400</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_401-500.html">Reports 401–500</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_501-600.html">Reports 501–600</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_601-700.html">Reports 601–700</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_701-800.html">Reports 701–800</a></li>
+  <li class="list-group-item"><a href="{{ site.baseurl }}/posts/posts_801-900.html">Reports 801–900</a></li>
 </ul>


### PR DESCRIPTION
## Summary
- use the default layout on all posts so that the navigation menu is visible
- link to generated HTML versions of the reports in the Social Media Posts page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b6151338832f93c9e30eb0734537