### PR TITLE
Add predictions index page

### DIFF
--- a/predictions/index.md
+++ b/predictions/index.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: "Predictions"
+---
+
+<ul>
+{% assign prediction_files = site.static_files | where_exp: "file", "file.path contains 'predictions/'" %}
+{% for file in prediction_files %}
+  {% unless file.path == 'predictions/index.md' %}
+    <li><a href="{{ file.path | relative_url }}">{{ file.name }}</a></li>
+  {% endunless %}
+{% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- create `predictions/index.md` listing all prediction files with Liquid loop

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684925704790832fae276058cb9ebb29