### PR TITLE
Add Predictions link to navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,6 +95,9 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ site.baseurl }}/shortSummaries/short_summaries.html">Contact Report Short Summaries</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ site.baseurl }}/predictions/">Predictions</a>
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a new nav item for Predictions page in default layout

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849256accac832fb8c087356d551de0