### PR TITLE
Fix predictions index listing

### DIFF
--- a/predictions/index.md
+++ b/predictions/index.md
@@ -4,10 +4,10 @@ title: "Predictions"
 ---
 
 <ul>
-{% assign prediction_files = site.static_files | where_exp: "file", "file.path contains 'predictions/'" %}
-{% for file in prediction_files %}
-  {% unless file.path == 'predictions/index.md' %}
-    <li><a href="{{ file.path | relative_url }}">{{ file.name }}</a></li>
+{% assign prediction_pages = site.pages | where_exp: 'page', "page.path contains 'predictions/'" %}
+{% for page in prediction_pages %}
+  {% unless page.path == 'predictions/index.md' %}
+    <li><a href="{{ page.url | relative_url }}">{{ page.name }}</a></li>
   {% endunless %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- fix predictions index to list pages instead of static files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684935e9b690832f8654ae1f341644c7