### PR TITLE
[codex] Record final supervisor closeout notes

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -27,3 +27,7 @@
 - When `P5` content is locally complete but git writes fail, keep `P5` active and blocked, rewrite workflow files around the new baseline, and require commit recovery before any `P6` movement.
 - Recover blocked `P5` work by committing the Stage 2 classifier change first, then the re-anchored export bundle, then the handoff evidence once git writes return.
 - Reconcile stale `.workflow` blockers against `git log`, `git status`, and the implementer report before keeping a pack blocked; once coherent commits land, advance the workflow to branch handoff and retire still-blocked future packs explicitly.
+- Rebuild missing `.workflow` supervisor files from the live doc set, `.workflow/history/`, current implementer report, and landed commit chain before making a new branch decision.
+- When a pack creates a deliberate Stage `2` carry-forward rerun, rewrite the branch handoff state around that new `stage2_run_key` and retire blocked future packs explicitly instead of leaving the old baseline in place.
+- When the core supervisor files already show `branch_complete`, still reconcile `.workflow/state.json` and `.workflow/run_log.md`; stale `supervisor_running` metadata can survive an interrupted rerun and misstate the live branch status.
+- If a supervisor closeout only needs a note-only commit, still test git writability first; this sandbox can leave `.workflow` updates local while blocking tracked-note commits on `.git/index.lock`.


### PR DESCRIPTION
## What changed
This branch records the final supervisor closeout notes after the `supervisor/loop47` workflow run.

It only updates `docs/agent_notes.md` with the stable lessons from the final handoff pass:
- rebuild missing `.workflow` supervisor files from the live doc set, `.workflow/history/`, the current implementer report, and landed commits before making a new branch decision
- when a pack creates a deliberate Stage 2 carry-forward rerun, rewrite branch handoff state around the new `stage2_run_key`
- reconcile stale `.workflow/state.json` and `.workflow/run_log.md` when the supervisor files already show `branch_complete`
- test git writability even for note-only closeout commits

## Why
The completed run did not authorize any new implementation pack. `P1` through `P5` were already accepted, `P6` remained retired/blocked for this doc set, and the branch ended in handoff state.

The only remaining tracked delta was the agent-notes update that documents how to avoid stale workflow metadata and false blocked states on future runs.

## Impact
There is no product or data-surface change in this branch.

This is a documentation-only closeout PR for the supervisor workflow notes.

## Root Cause
The final supervisor pass reconciled stale workflow metadata against the already-landed commit chain and confirmed the branch was complete. The missing repository artifact from that pass was only the tracked notes update.

## Validation
- `git rev-list --left-right --count main...HEAD` confirmed there was no implementation diff before this note-only commit
- reviewed `.workflow/current_implementer_report.md`, `.workflow/supervisor_decision.md`, `.workflow/current_supervisor_instruction.md`, `.workflow/branch_plan.md`, and `.workflow/slice_queue.md`
- confirmed the branch ended at `branch_complete` with `P6` retired on this branch
